### PR TITLE
Don't crash cli if user doesn't answer y/n confirmation request

### DIFF
--- a/client/input/input.go
+++ b/client/input/input.go
@@ -74,7 +74,12 @@ func GetConfirmation(prompt string, buf *bufio.Reader) (bool, error) {
 		return false, err
 	}
 
-	response = strings.ToLower(strings.TrimSpace(response))
+	response = strings.TrimSpace(response)
+	if len(response) == 0 {
+		return false, nil
+	}
+
+	response = strings.ToLower(response)
 	if response[0] == 'y' {
 		return true, nil
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
