### PR TITLE
R4R: Fix the q gov vote command to handle empty (pruned) votes correctly.

### DIFF
--- a/x/gov/client/cli/query.go
+++ b/x/gov/client/cli/query.go
@@ -215,9 +215,10 @@ $ %s query gov vote 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 			}
 
 			var vote types.Vote
-			if err := cdc.UnmarshalJSON(res, &vote); err != nil {
-				return err
-			}
+			// XXX: Allow the decoding to potentially fail as the vote may have been
+			// pruned from state. If so, decoding will fail and so we need to check the
+			// Empty() case. Consider updating Vote JSON decoding to not fail when empty.
+			_ = cdc.UnmarshalJSON(res, &vote)
 
 			if vote.Empty() {
 				res, err = gcutils.QueryVoteByTxQuery(cliCtx, params)
@@ -229,7 +230,7 @@ $ %s query gov vote 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 				}
 			}
 
-			return cliCtx.PrintOutput(vote) //nolint:errcheck
+			return cliCtx.PrintOutput(vote)
 		},
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
